### PR TITLE
Avoid allocating in `pre_exec` closure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,18 +221,12 @@ impl Command {
             builder.pre_exec(move || {
                 let err = libc::setsid();
                 if err == -1 {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        "Failed to set session id",
-                    ));
+                    return Err(std::io::Error::last_os_error());
                 }
 
                 let res = libc::ioctl(slave_fd, TIOCSCTTY as _, 0);
                 if res == -1 {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        format!("Failed to set controlling terminal: {}", res),
-                    ));
+                    return Err(std::io::Error::last_os_error());
                 }
 
                 libc::close(slave_fd);


### PR DESCRIPTION
`Error::new` allocates memory (see https://github.com/rust-lang/rust/pull/148971). This is bad in multi-threaded programs, which virtual-terminal as a library can be used in. If the fork occurs while the allocator lock is held by another thread, deadlocks can occur, since there's no one left in the new process to unlock the mutex. I do not believe this is UB, and modern libc offer protections against this issue, but this isn't POSIX-compliant and should preferably be avoided.

`last_os_error` does not allocate, but only supports error codes. However, the old method swallowed both the text and the error code, so hopefully that isn't a problem. If necessary, a valid approach to transmit an error would be to write to `stderr` (e.g. by panicking), but this is ugly.